### PR TITLE
Issue#21: Expose git hook input params as shell env vars

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -126,15 +126,6 @@
           "revision": "f43166a8e18fdd0857f29e303b1bb79a5428bca0",
           "version": "4.9.0"
         }
-      },
-      {
-        "package": "Yams",
-        "repositoryURL": "https://github.com/jpsim/Yams.git",
-        "state": {
-          "branch": null,
-          "revision": "b08dba4bcea978bf1ad37703a384097d3efce5af",
-          "version": "1.0.2"
-        }
       }
     ]
   },

--- a/Sources/Komondor/Commands/runner.swift
+++ b/Sources/Komondor/Commands/runner.swift
@@ -37,8 +37,11 @@ public func runner(logger _: Logger, args: [String]) throws {
     do {
         try commands.forEach { command in
             print("> \(command)")
+            let gitParams = Array(args.dropFirst())
+            // Exporting git hook input params as shell env var GIT_PARAMS
+            let cmd = "export GIT_PARAMS=\(gitParams.joined(separator: " ")) ; \(command)"
             // Simple is fine for now
-            print(try shellOut(to: command))
+            print(try shellOut(to: cmd))
             // Ideal:
             //   Store STDOUT and STDERR, and only show it if it fails
             //   Show a stepper like system of all commands

--- a/Sources/Komondor/Installation/renderScript.swift
+++ b/Sources/Komondor/Installation/renderScript.swift
@@ -22,7 +22,7 @@ public func renderScript(_ hookName: String, _ swiftPackagePath: String) -> Stri
           komondor=${komondor:-'swift run komondor'}
 
           # run hook
-          $komondor run \(hookName)
+          $komondor run \(hookName) $gitParams
         fi
         """
 }


### PR DESCRIPTION
This PR is more like a feature addition: able to execute shell scripts in addition to shell commands as part of git hooks.

The hooks configured in Package.swift needs to be prefixed with `sh:` or `cmd:` in order to let Komondor know whether it is executing a command or shell script

e.g.

```
#if canImport(PackageConfig)
    import PackageConfig

    let config = PackageConfiguration([
        "komondor": [
           "commit-msg":"sh: sh commitmsgcheck.sh",
            "pre-push": "cmd:swift test",
            "pre-commit": [
                "cmd:swift test",
                "cmd:swift run swiftformat .",
                "cmd:swift run swiftlint autocorrect --path Sources/",
                "cmd:git add .",
            ],
        ],
        "rocket": [
            "after": [
                "push",
            ],
        ],
    ]).write()
#endif
```