### PR TITLE
Show no-verify message on command fail

### DIFF
--- a/Sources/Komondor/Commands/install.swift
+++ b/Sources/Komondor/Commands/install.swift
@@ -25,6 +25,13 @@ let hookList = [
     "sendemail-validate"
 ]
 
+let skippableHooks = [
+    "commit-msg",
+    "pre-commit",
+    "pre-rebase",
+    "pre-push"
+]
+
 public func install(logger _: Logger) throws {
     // Add a skip env var
     let env = ProcessInfo.processInfo.environment

--- a/Sources/Komondor/Commands/runner.swift
+++ b/Sources/Komondor/Commands/runner.swift
@@ -2,7 +2,7 @@ import Foundation
 import PackageConfig
 import ShellOut
 
-// To emulate running the command as the script woudl do:
+// To emulate running the command as the script would do:
 //
 // swift run komondor run [hook-name]
 //
@@ -25,7 +25,7 @@ public func runner(logger _: Logger, args: [String]) throws {
         exit(1)
     }
 
-    var commands = [] as [String]
+    var commands: [String] = []
     if let stringOption = hookOptions as? String {
         commands = [stringOption]
     } else if let arrayOptions = hookOptions as? [String] {
@@ -36,7 +36,7 @@ public func runner(logger _: Logger, args: [String]) throws {
 
     do {
         try commands.forEach { command in
-            print("> \(command)")
+            print("[Komondor] > \(hook) \(command)")
             let gitParams = Array(args.dropFirst())
             // Exporting git hook input params as shell env var GIT_PARAMS
             let cmd = "export GIT_PARAMS=\(gitParams.joined(separator: " ")) ; \(command)"
@@ -49,6 +49,9 @@ public func runner(logger _: Logger, args: [String]) throws {
     } catch let error as ShellOutError {
         print(error.message)
         print(error.output)
+
+        let noVerifyMessage = skippableHooks.contains(hook) ? "add --no-verify to skip" : "cannot be skipped due to Git specs"
+        print("[Komondor] > \(hook) hook failed (\(noVerifyMessage))")
         exit(error.terminationStatus)
     } catch {
         print(error)


### PR DESCRIPTION
Implementation of #1. 

If a hook fails it will say if the hook can be skipped with the `--no-verify` flag. This mirrors the way husky behaves.