### PR TITLE
Specify edited files in commands

### DIFF
--- a/Sources/Komondor/Commands/runner.swift
+++ b/Sources/Komondor/Commands/runner.swift
@@ -33,18 +33,23 @@ public func runner(logger _: Logger, args: [String]) throws {
     }
 
     logger.debug("Running commands for komondor \(commands.joined())")
+    let stagedFiles = try getStagedFiles()
 
     do {
         try commands.forEach { command in
             print("[Komondor] > \(hook) \(command)")
             let gitParams = Array(args.dropFirst())
-            // Exporting git hook input params as shell env var GIT_PARAMS
-            let cmd = "export GIT_PARAMS=\(gitParams.joined(separator: " ")) ; \(command)"
-            // Simple is fine for now
-            print(try shellOut(to: cmd))
-            // Ideal:
-            //   Store STDOUT and STDERR, and only show it if it fails
-            //   Show a stepper like system of all commands
+            
+            let cmds = generateCommands(forCommand: command, withFiles: stagedFiles)
+            try cmds.forEach { cmd in
+                // Exporting git hook input params as shell env var GIT_PARAMS
+                let shellCmd = "export GIT_PARAMS=\(gitParams.joined(separator: " ")) ; \(cmd)"
+                // Simple is fine for now
+                print(try shellOut(to: shellCmd))
+                // Ideal:
+                //   Store STDOUT and STDERR, and only show it if it fails
+                //   Show a stepper like system of all commands
+            }
         }
     } catch let error as ShellOutError {
         print(error.message)
@@ -56,5 +61,30 @@ public func runner(logger _: Logger, args: [String]) throws {
     } catch {
         print(error)
         exit(1)
+    }
+}
+
+func getStagedFiles() throws -> [String] {
+    // Find the project root directory
+    let projectRootString = try shellOut(to: "git rev-parse --show-toplevel").trimmingCharacters(in: .whitespaces)
+    logger.debug("Found project root at: \(projectRootString)")
+    
+    let stagedFilesString = try shellOut(to: "git", arguments: ["diff", "--staged", "--diff-filter=ACM", "--name-only"], at: projectRootString)
+    logger.debug("Found staged files: \(stagedFilesString)")
+    
+    return stagedFilesString == "" ? [] : stagedFilesString.components(separatedBy: "\n")
+}
+
+func generateCommands(forCommand command: String, withFiles files: [String]) -> [String] {
+    guard let exts = parseEdited(command: command) else {
+        return [command]
+    }
+    
+    return files.filter { file in
+        exts.contains(where: { ext in
+            file.hasSuffix(".\(ext)")
+        })
+    }.map { file in
+        command.replacingOccurrences(of: editedRegexString, with: file, options: .regularExpression)
     }
 }

--- a/Sources/Komondor/Utils/Edited.swift
+++ b/Sources/Komondor/Utils/Edited.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+let editedRegexString = "\\[edited ([a-z]+)((?:,[a-z]+)*)\\]"
+
+func parseEdited(command: String) -> [String]? {
+    let range = NSRange(location: 0, length: command.utf16.count)
+
+    guard let regex = try? NSRegularExpression(pattern: editedRegexString) else {
+        fatalError("Malformed regex")
+    }
+
+    guard let match = regex.firstMatch(in: command, options: [], range: range) else {
+        return nil
+    }
+
+    guard let firstExtRange = Range(match.range(at: 1), in: command) else {
+        return nil
+    }
+    let firstExt = String(command[firstExtRange])
+
+    guard let restExtRange = Range(match.range(at: 2), in: command) else {
+        return [firstExt]
+    }
+    let restExt = command[restExtRange]
+    var extList = restExt.components(separatedBy: ",")
+    extList[0] = firstExt
+
+    return extList
+}

--- a/Sources/Komondor/Utils/Edited.swift
+++ b/Sources/Komondor/Utils/Edited.swift
@@ -1,28 +1,29 @@
 import Foundation
 
-let editedRegexString = "\\[edited ([a-z]+)((?:,[a-z]+)*)\\]"
+let editedRegexString = #"\[edited ([a-z]+)((?:,[a-z]+)*)\]"#
 
 func parseEdited(command: String) -> [String]? {
-    let range = NSRange(location: 0, length: command.utf16.count)
+    let range = NSRange(location: 0, length: command.count)
 
     guard let regex = try? NSRegularExpression(pattern: editedRegexString) else {
         fatalError("Malformed regex")
     }
 
-    guard let match = regex.firstMatch(in: command, options: [], range: range) else {
+    guard let match = regex.firstMatch(in: command, options: [], range: range),
+        let firstExtRange = Range(match.range(at: 1), in: command)
+    else {
         return nil
     }
 
-    guard let firstExtRange = Range(match.range(at: 1), in: command) else {
-        return nil
-    }
     let firstExt = String(command[firstExtRange])
-
     guard let restExtRange = Range(match.range(at: 2), in: command) else {
         return [firstExt]
     }
+
     let restExt = command[restExtRange]
     var extList = restExt.components(separatedBy: ",")
+    // extList[0] will be "" since there is was a leading comma
+    // replace it will the first extension
     extList[0] = firstExt
 
     return extList


### PR DESCRIPTION
Adds support for using `[edited <extensions>]` in a command. `<extensions>` can be one or more file extensions separated by commas. This will allow a command to be run only against changed files similar to lint-staged.

Ex: `[edited swift,ts,md]` would match all changed swift, typescript and markdown files.

#### Question
Would it still make sense to have `[edited]` without any extensions?

Fixes #6 