### PR TITLE
Fixing silent failure while creating the hooks

### DIFF
--- a/Documentation/config.md
+++ b/Documentation/config.md
@@ -32,7 +32,7 @@ These are all keys you can use in the config setting:
 #if canImport(PackageConfig)
     import PackageConfig
 
-    let config = PackageConfig([
+    let config = PackageConfiguration([
         "komondor": [
             "pre-commit": ["swift test", "swift run swiftFormat .", "git add ."],
             "pre-push": ["swift test", swift run danger-swift local", "swift run swiftlint"]

--- a/Documentation/only_xcode.md
+++ b/Documentation/only_xcode.md
@@ -49,8 +49,8 @@ let package = Package(
 ```
 
 > **Note**: See that _target_? You must have a target (right now) in your `Package.swift` in order to use
-> tools which come from your dependencies. Find a single source file which you can call the package using
-> the `path:` to find it's folder, and then `sources:` to set up that one target.
+> tools that come from your dependencies. Find a single source file that you can call the package with, using
+> the `path:` to find its folder, and then `sources:` to set up that one target.
 
 This adds `Komondor` to the app, and allows you to run the CLI for Komondor, you can verify by running
 `swift run komondor` and seeing the help message.
@@ -65,7 +65,7 @@ Next up: adding your git hooks to the config:
 + #if canImport(PackageConfig)
 +     import PackageConfig
 +
-+     let config = PackageConfig([
++     let config = PackageConfiguration([
 +         "komondor": [
 +             "pre-commit": "echo 'Hi'"
 +         ],

--- a/Sources/Komondor/Commands/install.swift
+++ b/Sources/Komondor/Commands/install.swift
@@ -74,8 +74,7 @@ public func install(logger _: Logger) throws {
 
     // Copy in the komondor templates
     try hookList.forEach { hookName in
-        var hookPath = URL(fileURLWithPath: hooksRoot.absoluteString)
-        hookPath.appendPathComponent(hookName)
+        let hookPath = hooksRoot.appendingPathComponent(hookName)
 
         // Separate header from script so we can
         // update if the script updates
@@ -90,8 +89,11 @@ public func install(logger _: Logger) throws {
 
         // Create it if it's not there
         if !fileManager.fileExists(atPath: hookPath.path) {
-            logger.debug("Added the hook: \(hookName)")
-            fileManager.createFile(atPath: hookPath.path, contents: hook.data(using: .utf8), attributes: execAttribute)
+            if fileManager.createFile(atPath: hookPath.path, contents: hook.data(using: .utf8), attributes: execAttribute) {
+                logger.debug("Added the hook: \(hookName)")
+            } else {
+                logger.logError("Could not add the hook: \(hookName)")
+            }
         } else {
             // Check if the script part has had an update since last running install
             let existingFileData = try Data(contentsOf: hookPath, options: [])


### PR DESCRIPTION
Hi, and thanks for this awesome project.

I had issues when I tried to install Komondor on a Xcode project of mine and this pull request aims to fix what went wrong: 

* Some docs were out of date;
* At first, the hooks were not created but were logged as they were;
* Then using a URL directly without going through `absoluteString` fixed it for me (and, funny anecdote, it was about the same fix that I suggested on [this StackOverflow question](https://stackoverflow.com/questions/63163756/the-file-couldnt-be-opened-because-there-is-no-such-file-when-getting-fileattri/63166495#63166495), a couple of weeks ago).

All in all, quite small changes, and now my setup works great! 🙏