### PR TITLE
Incorrect package name for `swiftformat`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This is from [the repo](https://github.com/shibapm/Komondor/blob/master/Package.
             "pre-push": "swift test",
             "pre-commit": [
                 "swift test",
-                "swift run swiftFormat .",
+                "swift run swiftformat .",
                 "swift run swiftlint autocorrect --path Sources/",
                 "git add .",
             ],


### PR DESCRIPTION
In my environment, `"swift run swiftFormat ."` does not work. The phrase ends up error message : `error: no executable product named 'swiftFormat'.`