### PR TITLE
Change directory to nested Package.swift

### DIFF
--- a/Sources/Komondor/Commands/install.swift
+++ b/Sources/Komondor/Commands/install.swift
@@ -72,6 +72,16 @@ public func install(logger _: Logger) throws {
     // TODO: What if Package.swift isn't in the CWD?
     let swiftPackagePath = "Package.swift"
 
+    // Relative path to folder containing Package.swift
+    let topLevelString = try shellOut(to: "git rev-parse --show-toplevel").trimmingCharacters(in: .whitespaces)
+    let cwd = fileManager.currentDirectoryPath
+    let swiftPackagePrefix: String?
+    if cwd.hasPrefix(topLevelString), cwd != topLevelString {
+        swiftPackagePrefix = "." + cwd.dropFirst(topLevelString.count)
+    } else {
+        swiftPackagePrefix = nil
+    }
+
     // Copy in the komondor templates
     try hookList.forEach { hookName in
         let hookPath = hooksRoot.appendingPathComponent(hookName)
@@ -79,7 +89,7 @@ public func install(logger _: Logger) throws {
         // Separate header from script so we can
         // update if the script updates
         let header = renderScriptHeader(hookName)
-        let script = renderScript(hookName, swiftPackagePath)
+        let script = renderScript(hookName, swiftPackagePath, swiftPackagePrefix)
         let hook = header + script
 
         // This is the same permissions that husky uses

--- a/Sources/Komondor/Installation/renderScript.swift
+++ b/Sources/Komondor/Installation/renderScript.swift
@@ -3,12 +3,14 @@
 ///
 /// If *this* changes then the template should be updated
 ///
-public func renderScript(_ hookName: String, _ swiftPackagePath: String) -> String {
+public func renderScript(_ hookName: String, _ swiftPackagePath: String, _ swiftPackagePrefix: String?) -> String {
+    let changeDir = swiftPackagePrefix.map { "cd \($0)\n" }
+        ?? ""
     return
         """
         hookName=`basename "$0"`
         gitParams="$*"
-
+        \(changeDir)
         if grep -q \(hookName) \(swiftPackagePath); then
           # use prebuilt binary if one exists, preferring release
           builds=( '.build/release/komondor' '.build/debug/komondor' )

--- a/Tests/KomondorTests/KomondorTests.swift
+++ b/Tests/KomondorTests/KomondorTests.swift
@@ -1,4 +1,4 @@
-@testable import komondor
+@testable import Komondor
 import XCTest
 
 final class KomondorTests: XCTestCase {


### PR DESCRIPTION
We had the same use as in #40. 
We have a Package in `./BuildTools` which includes Komondor among other tools.

To set up we run `cd BuildTools && swift run komondor install`. Though in the current master Komondor would head to the repositories' root and wouldn't find any Package.swift-file.

With this PR it would insert a simple `cd ./BuildTools` before looking for the manifest.
Therefore hooks will also be executed relative to the swift manifest.

---

An example of such a package in `BuildTools/Package.swift`:

```swift
// swift-tools-version:5.4
// The swift-tools-version declares the minimum version of Swift required to build this package.

import PackageDescription

let package = Package(
    name: "BuildTools",
    platforms: [.macOS(.v10_11)],
    dependencies: [
        .package(url: "https://github.com/nicklockwood/SwiftFormat.git", from: "0.48.6"),
        .package(url: "https://github.com/shibapm/Komondor.git", from: "1.0.6"),
        .package(url: "https://github.com/realm/SwiftLint.git", from: "0.43.1"),
        .package(url: "https://github.com/SwiftGen/SwiftGen.git", from: "6.4.0")
    ],
    targets: []
)

#if canImport(PackageConfig)
    import PackageConfig

    let config = PackageConfiguration([
        "komondor": [
            "pre-commit": [
                "cd .. && swift run -c release --package-path BuildTools swiftgen",
                "cd .. && swift run -c release --package-path BuildTools swiftformat --config .swiftformat ./**/*.swift",
                "cd .. && swift run -c release --package-path BuildTools swiftlint autocorrect",
                "cd .. && git add ."
            ]
        ]
    ]).write()
#endif

```