### PR TITLE
Update PackageConfig dependency from 1.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     dependencies: [
         // User deps
-        .package(url: "https://github.com/shibapm/PackageConfig.git", from: "0.13.0"),
+        .package(url: "https://github.com/shibapm/PackageConfig.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.1.0"),
         // Dev deps
         .package(url: "https://github.com/nicklockwood/SwiftFormat.git", from: "0.35.8"), // dev


### PR DESCRIPTION
Argument `from:` takes from `0.13.0...<1.0.0`, so the new release from PackageConfig cannot be used in Komondor. This bumps the requirement up to `1.0.0...<2.0.0`.