### PR TITLE
Support for a separate configuration file 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.build
 /Packages
 /*.xcodeproj
+xcuserdata/

--- a/Package.resolved
+++ b/Package.resolved
@@ -99,15 +99,6 @@
           "revision": "9183170d20857753d4f331b0ca63f73c60764bf3",
           "version": "5.0.2"
         }
-      },
-      {
-        "package": "Yams",
-        "repositoryURL": "https://github.com/jpsim/Yams",
-        "state": {
-          "branch": null,
-          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-          "version": "4.0.6"
-        }
       }
     ]
   },

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
         // User deps
         .package(url: "https://github.com/shibapm/PackageConfig.git", .upToNextMajor(from: "1.0.1")),
         .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.1.0"),
+        .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.6"),
         // Dev deps
         .package(url: "https://github.com/nicklockwood/SwiftFormat.git", from: "0.35.8"), // dev
         .package(url: "https://github.com/Realm/SwiftLint.git", from: "0.28.1"), // dev
@@ -19,7 +20,7 @@ let package = Package(
     targets: [
         .target(
             name: "Komondor",
-            dependencies: ["PackageConfig", "ShellOut"]
+            dependencies: ["PackageConfig", "ShellOut", "Yams"]
         ),
     ]
 )

--- a/Sources/Komondor/Commands/install.swift
+++ b/Sources/Komondor/Commands/install.swift
@@ -32,7 +32,7 @@ let skippableHooks = [
     "pre-push"
 ]
 
-public func install(logger _: Logger) throws {
+public func install(logger _: Logger, usingConfigFile: Bool = false) throws {
     // Add a skip env var
     let env = ProcessInfo.processInfo.environment
     if env["SKIP_KOMONDOR"] != nil {
@@ -86,7 +86,7 @@ public func install(logger _: Logger) throws {
         // Separate header from script so we can
         // update if the script updates
         let header = renderScriptHeader(hookName)
-        let script = renderScript(hookName, swiftPackagePrefix)
+        let script = renderScript(hookName, swiftPackagePrefix, usingConfigFile)
         let hook = header + script
 
         // This is the same permissions that husky uses

--- a/Sources/Komondor/Commands/runner.swift
+++ b/Sources/Komondor/Commands/runner.swift
@@ -7,18 +7,13 @@ import ShellOut
 // swift run komondor run [hook-name]
 //
 //
-public func runner(logger _: Logger, args: [String]) throws {
-    let pkgConfig = try PackageConfiguration.load()
-
+public func runner(logger: Logger, configSource: ConfigSource, args: [String]) throws {
     guard let hook = args.first else {
         logger.logError("[Komondor] The runner was called without a hook")
         exit(1)
     }
 
-    guard let config = pkgConfig["komondor"] as? [String: Any] else {
-        logger.logError("[Komondor] Could not find komondor settings inside the Package.swift")
-        exit(1)
-    }
+    let config = try configSource.config
 
     if let hookOptions = config[hook] {
         var commands: [String] = []

--- a/Sources/Komondor/Installation/renderScript.swift
+++ b/Sources/Komondor/Installation/renderScript.swift
@@ -3,9 +3,11 @@
 ///
 /// If *this* changes then the template should be updated
 ///
-public func renderScript(_ hookName: String, _ swiftPackagePrefix: String?) -> String {
+public func renderScript(_ hookName: String, _ swiftPackagePrefix: String?, _ usingConfigFile: Bool = false) -> String {
     let changeDir = swiftPackagePrefix.map { "cd \($0)\n" }
         ?? ""
+  
+    let useConfigFile = usingConfigFile ? "--use-config-file" : ""
     return
         """
         hookName=`basename "$0"`
@@ -23,6 +25,6 @@ public func renderScript(_ hookName: String, _ swiftPackagePrefix: String?) -> S
         komondor=${komondor:-'swift run komondor'}
 
         # run hook
-        $komondor run \(hookName) $gitParams
+        $komondor run \(hookName) $gitParams \(useConfigFile)
         """
 }

--- a/Sources/Komondor/Utils/ConfigSource/ConfigSource.swift
+++ b/Sources/Komondor/Utils/ConfigSource/ConfigSource.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol ConfigSource {
+    var config: [String: Any] { get throws }
+}

--- a/Sources/Komondor/Utils/ConfigSource/FileConfigSource.swift
+++ b/Sources/Komondor/Utils/ConfigSource/FileConfigSource.swift
@@ -1,0 +1,30 @@
+import Foundation
+import ShellOut
+import Yams
+
+public struct FileConfigSource: ConfigSource {
+    let logger: Logger
+
+    public init(logger: Logger) {
+        self.logger = logger
+    }
+
+    public var config: [String: Any] {
+        get throws {
+            let path = try shellOut(to: "git rev-parse --show-toplevel")
+                .trimmingCharacters(in: .whitespaces)
+                .appending("/komondor.yml")
+
+            let yaml = try String(contentsOfFile: path)
+            let config = try Yams.load(yaml: yaml)
+
+            guard let config = config as? [String: Any] else {
+                logger.logError("[Komondor] Could not load komondor configuration from file at \(path)")
+
+                exit(1)
+            }
+
+            return config
+        }
+    }
+}

--- a/Sources/Komondor/Utils/ConfigSource/PackageConfigSource.swift
+++ b/Sources/Komondor/Utils/ConfigSource/PackageConfigSource.swift
@@ -1,0 +1,24 @@
+import Foundation
+import PackageConfig
+
+public struct PackageConfigSource: ConfigSource {
+    let logger: Logger
+
+    public init(logger: Logger) {
+        self.logger = logger
+    }
+
+    public var config: [String: Any] {
+        get throws {
+            let pkgConfig = try PackageConfiguration.load()
+
+            guard let values = pkgConfig["komondor"] as? [String: Any] else {
+                logger.logError("[Komondor] Could not find komondor settings inside the Package.swift")
+
+                exit(1)
+            }
+
+            return values
+        }
+    }
+}

--- a/Sources/Komondor/main.swift
+++ b/Sources/Komondor/main.swift
@@ -5,6 +5,8 @@ public let KomondorVersion = "1.0.0"
 
 let isVerbose = CommandLine.arguments.contains("--verbose") || (ProcessInfo.processInfo.environment["DEBUG"] != nil)
 let isSilent = CommandLine.arguments.contains("--silent")
+let isUsingFileConfig = CommandLine.arguments.contains("--use-file-config")
+
 let logger = Logger(isVerbose: isVerbose, isSilent: isSilent)
 logger.debug("Setting up .git-hooks for Komondor (v\(KomondorVersion))")
 
@@ -29,8 +31,9 @@ switch task {
 case "install":
     try install(logger: logger)
 case "run":
+    let configSource: ConfigSource = isUsingFileConfig ? FileConfigSource(logger: logger) : PackageConfigSource(logger: logger)
     let runnerArgs = Array(CommandLine.arguments.dropFirst().dropFirst())
-    try runner(logger: logger, args: runnerArgs)
+    try runner(logger: logger, configSource: configSource, args: runnerArgs)
 case "uninstall":
     try uninstall(logger: logger)
 default:

--- a/Sources/Komondor/main.swift
+++ b/Sources/Komondor/main.swift
@@ -5,7 +5,7 @@ public let KomondorVersion = "1.0.0"
 
 let isVerbose = CommandLine.arguments.contains("--verbose") || (ProcessInfo.processInfo.environment["DEBUG"] != nil)
 let isSilent = CommandLine.arguments.contains("--silent")
-let isUsingFileConfig = CommandLine.arguments.contains("--use-file-config")
+let isUsingConfigFile = CommandLine.arguments.contains("--use-config-file")
 
 let logger = Logger(isVerbose: isVerbose, isSilent: isSilent)
 logger.debug("Setting up .git-hooks for Komondor (v\(KomondorVersion))")
@@ -29,9 +29,9 @@ let task = CommandLine.arguments[1]
 
 switch task {
 case "install":
-    try install(logger: logger)
+    try install(logger: logger, usingConfigFile: isUsingConfigFile)
 case "run":
-    let configSource: ConfigSource = isUsingFileConfig ? FileConfigSource(logger: logger) : PackageConfigSource(logger: logger)
+    let configSource: ConfigSource = isUsingConfigFile ? FileConfigSource(logger: logger) : PackageConfigSource(logger: logger)
     let runnerArgs = Array(CommandLine.arguments.dropFirst().dropFirst())
     try runner(logger: logger, configSource: configSource, args: runnerArgs)
 case "uninstall":


### PR DESCRIPTION
## Context 
This PR adds support for a separate config file that could be used instead of `Package.swift` to configure the `komondor` git hooks. The separate config file is a viable choice when you wanna `komondor` with something like [Mint](https://github.com/yonaskolb/Mint) or other similar tools. 

By default, `komondor` is going to use `Package.swift` to configure hooks and when `--use-config-file` flag is being used `komondor` gonna try to use `komondor.yml` file from the project root folder. 

`--use-config-file` flag is supported by `install` and `run` commands. 

## Examples
### With install command 
```sh
swift run -c release komondor install --use-config-file
```

### With run command 
```sh
swift run -c release komondor run pre-commit --use-config-file
```

### Additional Notes
1. This closes #19 
2. This PR doesn't contain any unit tests because with the current package setup it's really hard to have any. I think to support the unit tests properly the majority of `komondor` source code needs to be moved to a _separate target_. I think this kind of change is a little bit out of the scope of this PR. It shall be relatively straightforward to extract the source code into a separate target (e.g. `KomondorCore` or `KomondorFramework`) and shall be probably done in a separate PR.