### PR TITLE
Fix Future Package Conflicts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         // Dev deps
         .package(url: "https://github.com/nicklockwood/SwiftFormat.git", from: "0.35.8"), // dev
         .package(url: "https://github.com/Realm/SwiftLint.git", from: "0.28.1"), // dev
-        .package(url: "https://github.com/f-meloni/Rocket", from: "1.2.1"), // dev
+        .package(url: "https://github.com/shibapm/Rocket", from: "1.2.1"), // dev
     ],
     targets: [
         .target(


### PR DESCRIPTION
If someone is using Rocket there's a potential for conflicts in the future:
> 'komondor': warning: 'komondor' dependency on 'https://github.com/f-meloni/Rocket' conflicts with dependency on 'https://github.com/shibapm/Rocket' which has the same identity 'rocket'. this will be escalated to an error in future versions of SwiftPM.

This fixes that issue in the future.